### PR TITLE
Commented out the content of onHostDestroy in RNOneSignal.java

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -434,8 +434,8 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
 
    @Override
    public void onHostDestroy() {
-      OneSignal.removeNotificationOpenedHandler();
-      OneSignal.removeNotificationReceivedHandler();
+//       OneSignal.removeNotificationOpenedHandler();
+//       OneSignal.removeNotificationReceivedHandler();
    }
 
    @Override


### PR DESCRIPTION
This fixes the issue when onReceive would stop working after app going to background. Absolutely no idea what I'm doing ¯\\_(ツ)_/¯
Some guy here suggested it:
https://github.com/geektimecoil/react-native-onesignal/issues/606#issuecomment-427554403